### PR TITLE
Fix ssp stutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+/* Eclipse */
 /eclipse
+/.classpath
+/.project
+/.settings
+/bin
+
 /.idea
 /build
 /.gradle

--- a/src/main/java/ru/itaros/backport5160/Forge5160ModContainer.java
+++ b/src/main/java/ru/itaros/backport5160/Forge5160ModContainer.java
@@ -22,7 +22,7 @@ public class Forge5160ModContainer extends DummyModContainer {
                 "Made specifically for fan of railcarts(Kane Hart) and lovers of pain(GTNH)";
         meta.version = "1.7.10";
         meta.authorList = Collections.singletonList("Itaros");
-        meta.credits = "gabizou, aikar, liach, williewillus, LexManos, tterrag1098, bs2609";
+        meta.credits = "gabizou, aikar, liach, williewillus, LexManos, tterrag1098, bs2609, makamys";
     }
 
     @Override


### PR DESCRIPTION
I implemented the World.isRemote checks added in https://github.com/MinecraftForge/MinecraftForge/pull/5168 and https://github.com/MinecraftForge/MinecraftForge/pull/5170 in the Entity class. This fixes the stuttering in singleplayer described in #1.

While I'm here, an answer to your "Wut?" comments: https://github.com/Itaros/minecraft-backport5160/blob/f7f9b990217956342320097838d82987893bcfa2/src/main/java/ru/itaros/backport5160/Forge5160Transformer.java#L15-L22
And this:
https://github.com/Itaros/minecraft-backport5160/blob/f7f9b990217956342320097838d82987893bcfa2/src/main/java/ru/itaros/backport5160/Forge5160Transformer.java#L119
None of the changes linked in those comments were introduced by PR 5160, so they are irrelevant. (If you look in 1.7.0's Forge-patched Chunk class, you can see the event bus stuff is already all there.) I think you were confused by the fact that you are looking at the diff of a diff: there are some lines that start with "+", but these +s are characters in the patch file, they don't mean the lines were added by that commit. The relevant lines begin with a "+ +". This confused me at first as well.

Also, I made a roadmap of the project's progress to help stay organized and make sure I don't miss anything. You may want to add this to the readme or a wiki page to help future coordination.
(X means it was already implemented, + means this PR implements it)

```
[ ] 5160
	[x] 0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
		[x] Chunk
			[x] markDirty on add
			[x] markDirty on remove
	[ ] 0315-Always-process-chunk-registration-after-moving.patch
		[x] World
			[x] implement paper's "valid" as "isAddedToWorld"
				[x] call onAddedToWorld in onEntityAdded
				[x] call onRemovedFromWorld onEntityRemoved
		[x] Entity
			[x] implement paper's "valid" as "isAddedToWorld"
				[x] isAddedToWorld
				[x] onAddedToWorld
				[x] onRemovedFromWorld
			[x] setPosition: if (valid) world.entityJoinedWorld(this, false); // Paper - ensure Entity is moved to its proper chunk
			[x] resetPositionToBB: if (valid) world.entityJoinedWorld(this, false); // Paper - ensure Entity is moved to its proper chunk
		[ ] EntityLeashKnot
			[ ] if (valid) world.entityJoinedWorld(this, false); // Paper - ensure Entity is moved to its proper chunk
		[x] EntityShulker: [not present]
	[x] 0335-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
		[x] Entity
			[x] world.getChunkAt((int) Math.floor(this.locX) >> 4, (int) Math.floor(this.locZ) >> 4); // Paper - ensure chunk is always loaded
	[ ] 0378-Sync-Player-Position-to-Vehicles.patch
		[ ] NetHandlerPlayServer
			[x] Location curPos = getPlayer().getLocation(); // Paper [not present in 5160]
			[ ] player.setLocation(d3, d4, d5, f, f1); // Paper
			[ ] player.setLocation(d0, d1, d2, f, f1); // Paper
			[x] //Location curPos = player.getLocation(); // Paper - move up [not present in 5160]
[ ] 5168 + 5170
	[+] Entity
		[+] isRemote check #1
		[+] isRemote check #2
		[+] isRemote check #3
	[ ] EntityLeashKnot
		[ ] isRemote check (depends on implementing EntityLeashKnot stuff first)
	[x] EntityShulker [not present in 1.7.10]
[ ] 5233
	[ ] NetHandlerPlayServer (depends on implementing NetHandlerPlayServer stuff first)
		[ ] change #1
		[ ] change #2
```